### PR TITLE
Force the language level of Drools to 1.6

### DIFF
--- a/src/main/java/edu/isi/bmkeg/lapdf/classification/ruleBased/RuleBasedChunkClassifier.java
+++ b/src/main/java/edu/isi/bmkeg/lapdf/classification/ruleBased/RuleBasedChunkClassifier.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
 
 import org.apache.log4j.Logger;
 import org.drools.KnowledgeBase;
@@ -11,9 +12,11 @@ import org.drools.KnowledgeBaseFactory;
 import org.drools.builder.DecisionTableConfiguration;
 import org.drools.builder.DecisionTableInputType;
 import org.drools.builder.KnowledgeBuilder;
+import org.drools.builder.KnowledgeBuilderConfiguration;
 import org.drools.builder.KnowledgeBuilderFactory;
 import org.drools.builder.ResourceType;
 import org.drools.compiler.DecisionTableFactory;
+import org.drools.compiler.PackageBuilderConfiguration;
 import org.drools.definition.KnowledgePackage;
 import org.drools.io.Resource;
 import org.drools.io.ResourceFactory;
@@ -51,7 +54,11 @@ public class RuleBasedChunkClassifier implements Classifier<ChunkBlock> {
 	public RuleBasedChunkClassifier(String droolsFileName,
 			AbstractModelFactory modelFactory) throws IOException, ClassificationException  {
 
-		KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
+		// Workaround for JBRULES-3163
+		Properties properties = new Properties();
+		properties.setProperty( "drools.dialect.java.compiler.lnglevel", "1.6" );
+		PackageBuilderConfiguration cfg = new PackageBuilderConfiguration( properties );
+		KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder( cfg );
 		kbase = KnowledgeBaseFactory.newKnowledgeBase();
 		
 		File expandedFile = null;


### PR DESCRIPTION
When running with Java 7 or higher Drools will try to use that java language level, but then fail as
it is not supported until Drools 5.2.1.FINAL (see JBRULES-3163).
Updating to 5.2.1.FINAL might break other rules, so this is the "safer" approach.
