### PR TITLE
Make word-extraction more resilient

### DIFF
--- a/src/main/java/edu/isi/bmkeg/lapdf/extraction/JPedalExtractor.java
+++ b/src/main/java/edu/isi/bmkeg/lapdf/extraction/JPedalExtractor.java
@@ -145,7 +145,7 @@ public class JPedalExtractor implements Extractor {
 
 	}
 
-	private void decodeFile() throws Exception {
+	private boolean decodeFile() throws Exception {
 
 		String font = null;
 		String currentWord;
@@ -178,7 +178,7 @@ public class JPedalExtractor implements Extractor {
 		if( words == null ) {
 			currentPage++;
 			PDFDecoder.flushObjectValues(false);
-			return;
+			return false;
 		}
 
 		Iterator<String> wordIterator = words.iterator();
@@ -222,38 +222,44 @@ public class JPedalExtractor implements Extractor {
 		
 		currentPage++;
 		PDFDecoder.flushObjectValues(false);
+
+		return true;
 	
 	}
 
 	@Override
 	public boolean hasNext() {
-		
-		if (currentPage <= pageCount) {
+
+		boolean haveNext = false;
+
+		while (currentPage <= pageCount && !haveNext) {
 
 			try {
-		
-				decodeFile();
+
+				haveNext = decodeFile();
 
 			} catch (EmptyPDFException e) {
-			
-				return false;
+
+				break;
 
 			} catch (Exception e) {
-			
+
 				e.printStackTrace();
-				return false;
-			
+				break;
+
 			}
 
-			return true;
-		
-		} else {
-		
+		}
+
+		if (currentPage == pageCount + 1) {
+
 			PDFDecoder.flushObjectValues(true);
 			PDFDecoder.closePdfFile();
-			return false;
-		
+			haveNext = false;
+
 		}
+
+		return haveNext;
 
 	}
 


### PR DESCRIPTION
If the first page of the document is empty, wordListPerPage is not populated, but #decodeFile()
will return in a way that #hasNext() returns true (correctly). #next() however will fail
with a NullPointerException when called.

Fix that by letting #decodeFile() return whether it found any words, and loop until either that
is the case or all pages have been processed.
